### PR TITLE
Fix CI failure by removing missing shell test references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ jobs:
       - name: Run unit tests
         run: npm test
 
-      - name: Run shell script tests
-        run: npm run test:shell
 
   docker-build:
     name: Docker Build Verification

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 - JSDoc for public functions
 - 한글 주석은 영어로 변환
 
-## Folder Structure and Architecture
+## Directory Structure
 
 
 ```
@@ -50,3 +50,6 @@ tests/
 ```
 
 ## Important Notes
+
+- Every Feature must be **logged**!
+- Every Feature must be **Testable**.

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:shell": "bash tests/scripts/run_all_tests.sh",
-    "test:all": "npm test && npm run test:shell"
+    "test:all": "npm test"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Remove test:shell script and CI step that referenced non-existent tests/scripts/run_all_tests.sh, update CLAUDE.md structure docs.