### PR TITLE
Fix Dockerfile to use Node 20 for ARM v7 support

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
 
-FROM node:lts-slim
+FROM node:20-slim
 
 # Install build dependencies for better-sqlite3 and Chromium for puppeteer
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Node 22 (lts) does not provide linux/arm/v7 Docker images. Pin to Node 20-slim which supports Raspberry Pi 3B+ (armv7l).