### PR TITLE
Fix SQLite CANTOPEN error by matching container user UID

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -23,11 +23,9 @@ COPY . .
 # Create data directory for SQLite database
 RUN mkdir -p /app/data
 
-# Run as non-root user for security
-RUN groupadd -g 1001 botuser && \
-    useradd -u 1001 -g botuser botuser && \
-    chown -R botuser:botuser /app
-USER botuser
+# Run as non-root user for security (node user uid=1000 matches host pi user)
+RUN chown -R node:node /app
+USER node
 
 # Start the bot
 CMD ["node", "src/index.js"]


### PR DESCRIPTION
Use built-in node user (uid=1000) instead of custom botuser (uid=1001) to match host pi user, fixing volume mount permission issue.