### PR TITLE
Fix SQLITE_READONLY by adding entrypoint with gosu for volume permiss…

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -3,7 +3,7 @@ FROM node:20-slim
 
 # Install build dependencies for better-sqlite3 and Chromium for puppeteer
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 make g++ chromium \
+    python3 make g++ chromium gosu \
     && rm -rf /var/lib/apt/lists/*
 
 
@@ -23,9 +23,13 @@ COPY . .
 # Create data directory for SQLite database
 RUN mkdir -p /app/data
 
-# Run as non-root user for security (node user uid=1000 matches host pi user)
+# Ensure app ownership for node user
 RUN chown -R node:node /app
-USER node
 
-# Start the bot
+# Copy entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Entrypoint fixes data dir permissions then drops to node user via gosu
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["node", "src/index.js"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Fix ownership of mounted data directory so node user can write
+chown -R node:node /app/data
+
+# Drop privileges and execute as node user
+exec gosu node "$@"


### PR DESCRIPTION
…ions

Docker bind mount uses host directory ownership, causing node user to lack write access. Entrypoint script fixes /app/data ownership as root before dropping privileges to node user via gosu.