### PR TITLE
Optimize Docker build for Raspberry Pi with multi-stage build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3.8'
 
 services:
   mettaton:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: mettaton-bot
     restart: unless-stopped
     environment:
@@ -14,6 +16,7 @@ services:
       - QUESTION_CHANNEL_ID=${QUESTION_CHANNEL_ID}
       - PRACTICE_CHANNEL_ID=${PRACTICE_CHANNEL_ID}
       - DB_PATH=/app/data/mettaton.db
+      - CHROMIUM_PATH=/usr/bin/chromium
     volumes:
       - ./data:/app/data
       - ./moon_calendars:/app/moon_calendars

--- a/scripts/mettaton-update.service
+++ b/scripts/mettaton-update.service
@@ -14,4 +14,4 @@ StandardError=journal
 # Resource limits for Raspberry Pi 3B+
 Nice=19
 IOSchedulingClass=idle
-MemoryMax=256M
+MemoryMax=512M

--- a/scripts/mettaton.service
+++ b/scripts/mettaton.service
@@ -10,7 +10,7 @@ RemainAfterExit=yes
 WorkingDirectory=/home/pi/mettaton
 ExecStart=/usr/bin/docker compose up -d --build
 ExecStop=/usr/bin/docker compose down
-TimeoutStartSec=300
+TimeoutStartSec=900
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -19,6 +19,10 @@ HEALTH_CHECK_RETRIES=6
 HEALTH_CHECK_INTERVAL=10
 LOCK_FILE="/tmp/mettaton-update.lock"
 
+# Docker Compose timeout for slow Raspberry Pi builds (default 60s is too low)
+export COMPOSE_HTTP_TIMEOUT=600
+export DOCKER_CLIENT_TIMEOUT=600
+
 # ============================================================
 # Argument Parsing
 # ============================================================


### PR DESCRIPTION
- Split Dockerfile into builder (build tools) and runtime (chromium, gosu) stages for better layer caching and ~150-200MB smaller image
- Separate chromium and gosu into individual layers so partial failure doesn't invalidate the other
- Increase COMPOSE_HTTP_TIMEOUT/DOCKER_CLIENT_TIMEOUT to 600s
- Increase systemd TimeoutStartSec to 900s and MemoryMax to 512M
- Add CHROMIUM_PATH env for puppeteer-core