### PR TITLE
Expand database sync from 3 phases to 6 phases

### DIFF
--- a/.claude/feature-forms/DATABASE_SYNC.md
+++ b/.claude/feature-forms/DATABASE_SYNC.md
@@ -5,7 +5,8 @@ Database Sync (데이터베이스 동기화)
 
 ## Feature Description
 디스코드 서버의 현재 상태와 데이터베이스를 동기화하는 기능.
-회원 활동 기록, 강의 참석자, 메시지 ID 유효성을 3단계로 검증 및 정리한다.
+회원 활동 기록, 참석자 정리, 메시지 ID 유효성, 활동 포인트, 개인수행 데이터를 6단계로 검증 및 정리한다.
+퀴즈 답변(quiz_answers)은 통계 무결성을 위해 동기화 대상에서 제외한다.
 
 ## CRUD Definition
 
@@ -21,7 +22,7 @@ Database Sync (데이터베이스 동기화)
 ### Sync (`/동기화`)
 | Key | String | Params | Customizable |
 |-----|--------|--------|:---:|
-| `sync.complete` | `✅ 동기화가 완료되었습니다.\n\n**회원 활동 동기화:**\n- 추가된 회원: {membersAdded}명\n- 제거된 회원: {membersRemoved}명\n\n**강의 참석자 정리:**\n- 제거된 참석 기록: {attendeesRemoved}건\n\n**메시지 ID 검증:**\n- 정리된 강의 메시지: {lectureMessagesCleaned}건\n- 정리된 질문 메시지: {questionMessagesCleaned}건` | membersAdded, membersRemoved, attendeesRemoved, lectureMessagesCleaned, questionMessagesCleaned | Yes |
+| `sync.complete` | `✅ 동기화가 완료되었습니다.\n\n**Phase 1 - 회원 활동 동기화:**\n- 추가된 회원: {membersAdded}명\n- 제거된 회원: {membersRemoved}명\n\n**Phase 2 - 참석자 정리:**\n- 제거된 일정 참석 기록: {lectureAttendeesRemoved}건\n- 제거된 질문 참석 기록: {questionAttendeesRemoved}건\n\n**Phase 3 - 메시지 ID 검증:**\n- 정리된 일정 메시지: {lectureMessagesCleaned}건\n- 정리된 질문 메시지: {questionMessagesCleaned}건\n- 정리된 수행계획 메시지: {practiceMessagesCleaned}건\n- 정리된 퀴즈 메시지: {quizMessagesCleaned}건\n\n**Phase 4 - 활동 포인트 정리:**\n- 제거된 포인트 기록: {pointsRemoved}건\n- 제거된 적립 로그: {accumulationLogsRemoved}건\n\n**Phase 5 - 개인수행 정리:**\n- 제거된 수행 계획: {practicesRemoved}건\n- 제거된 수행 기록: {practiceRecordsRemoved}건\n\n**Phase 6 - 퀴즈 출제 이력 정리:**\n- 정리된 고아 출제 이력: {quizHistoryCleaned}건` | membersAdded, membersRemoved, lectureAttendeesRemoved, questionAttendeesRemoved, lectureMessagesCleaned, questionMessagesCleaned, practiceMessagesCleaned, quizMessagesCleaned, pointsRemoved, accumulationLogsRemoved, practicesRemoved, practiceRecordsRemoved, quizHistoryCleaned | Yes |
 | `sync.error` | `❌ 동기화 중 오류가 발생했습니다: {error}` | error | Yes |
 
 ## Permission
@@ -39,10 +40,39 @@ Database Sync (데이터베이스 동기화)
   - 서버에 있지만 DB에 없는 회원 → member_activity에 추가
   - DB에 있지만 서버에 없는 회원 → member_activity에서 제거
   - 봇 계정은 제외
-- **Phase 2: 강의 참석자 정리**
-  - 서버에 없는 회원의 강의 참석 기록 제거
+- **Phase 2: 참석자 정리**
+  - 서버에 없는 회원의 일정(lecture) 참석 기록 제거 (lecture_attendees)
+  - 서버에 없는 회원의 질문(question) 참석 기록 제거 (question_attendees)
 - **Phase 3: 메시지 ID 검증**
   - 일정 채널에서 lecture의 message_id 유효성 확인 → 없으면 message_id 초기화
   - 질문 채널에서 question의 message_id 유효성 확인 → 없으면 message_id 초기화
+  - 수행계획방 채널에서 personal_practice_plans의 message_id 유효성 확인 → 없으면 message_id 초기화
+  - 퀴즈 채널에서 quiz_publish_history의 message_id 유효성 확인 → 없으면 message_id 초기화
+- **Phase 4: 활동 포인트 정리**
+  - 서버에 없는 회원의 activity_points 기록 제거
+  - 서버에 없는 회원의 point_accumulation_log 기록 제거
+  - point_award_history는 적립 이력으로 보존 (통계 목적)
+- **Phase 5: 개인수행 정리**
+  - 서버에 없는 회원의 personal_practice_plans 제거
+  - 해당 계획의 personal_practice_records도 함께 제거 (CASCADE 또는 명시적 삭제)
+  - 삭제 대상 계획의 Embed 메시지가 남아있으면 수행계획방 채널에서 삭제 시도
+- **Phase 6: 퀴즈 출제 이력 정리**
+  - 삭제된 문제(quiz_questions에 존재하지 않는 question_id)를 참조하는 quiz_publish_history 기록 정리
+  - quiz_answers는 통계 무결성(정답률, 참여자 수)을 위해 동기화 대상에서 제외
 - 각 Phase의 처리 건수를 결과로 표시
 - 오류 발생 시 에러 메시지와 함께 상세 내용 표시
+
+## Sync Exclusions
+다음 테이블은 동기화 대상에서 **의도적으로 제외**:
+| Table | Reason |
+|-------|--------|
+| quiz_answers | 퀴즈 통계(정답률, 참여자 수)의 무결성 보존 |
+| point_award_history | 포인트 적립 이력 보존 (통계/감사 목적) |
+| quiz_questions | 문제 데이터는 서버 회원과 무관 (관리자 등록 콘텐츠) |
+| quiz_config | 싱글턴 설정 데이터 |
+| quiz_categories | 카테고리 마스터 데이터 |
+| activity_type_config | 활동 유형 설정 데이터 |
+| point_config | 포인트 전역 설정 데이터 |
+| meeting_config | 수행 모임 설정 데이터 |
+| bot_strings | 봇 문자열 설정 데이터 |
+| settings | 전역 설정 데이터 |

--- a/src/presentation/controllers/sync/sync.js
+++ b/src/presentation/controllers/sync/sync.js
@@ -26,12 +26,21 @@ module.exports = {
       const results = {
         membersAdded: 0,
         membersRemoved: 0,
-        attendeesRemoved: 0,
+        lectureAttendeesRemoved: 0,
+        questionAttendeesRemoved: 0,
         lectureMessagesCleaned: 0,
         questionMessagesCleaned: 0,
+        practiceMessagesCleaned: 0,
+        quizMessagesCleaned: 0,
+        pointsRemoved: 0,
+        accumulationLogsRemoved: 0,
+        practicesRemoved: 0,
+        practiceRecordsRemoved: 0,
+        quizHistoryCleaned: 0,
       };
 
       // Phase 1: Member activity sync
+      console.log('[sync/phase1] Starting member activity sync');
       for (const memberId of guildMemberIds) {
         if (repository.insertMemberActivityIfMissing(memberId)) {
           results.membersAdded++;
@@ -45,26 +54,42 @@ module.exports = {
           results.membersRemoved++;
         }
       }
+      console.log(`[sync/phase1] Completed: added=${results.membersAdded}, removed=${results.membersRemoved}`);
 
-      // Phase 2: Lecture attendees cleanup
+      // Phase 2: Attendees cleanup (lecture + question)
+      console.log('[sync/phase2] Starting attendees cleanup');
       const lectures = repository.getAllLectures();
       for (const lecture of lectures) {
         for (const userId of lecture.attendees) {
           if (!guildMemberIds.has(userId)) {
             repository.removeAttendee(lecture.id, userId);
-            results.attendeesRemoved++;
+            results.lectureAttendeesRemoved++;
           }
         }
       }
 
-      // Phase 3: Message ID verification
+      const questions = repository.getAllQuestions();
+      for (const question of questions) {
+        for (const userId of question.attendees) {
+          if (!guildMemberIds.has(userId)) {
+            repository.removeQuestionAttendee(question.id, userId);
+            results.questionAttendeesRemoved++;
+          }
+        }
+      }
+      console.log(`[sync/phase2] Completed: lectureAttendees=${results.lectureAttendeesRemoved}, questionAttendees=${results.questionAttendeesRemoved}`);
+
+      // Phase 3: Message ID verification (lecture, question, practice, quiz)
+      console.log('[sync/phase3] Starting message ID verification');
+
       const scheduleChannel = guild.channels.cache.get(config.channels.schedule);
       if (scheduleChannel) {
         for (const lecture of lectures) {
           if (lecture.messageId) {
             try {
               await scheduleChannel.messages.fetch(lecture.messageId);
-            } catch {
+            } catch (error) {
+              console.log(`[sync/phase3] DiscordAPIError: Lecture message #${lecture.messageId} not found, clearing`);
               repository.clearLectureMessageId(lecture.id);
               results.lectureMessagesCleaned++;
             }
@@ -73,13 +98,13 @@ module.exports = {
       }
 
       const questionChannel = guild.channels.cache.get(config.channels.question);
-      const questions = repository.getAllQuestions();
       if (questionChannel) {
         for (const question of questions) {
           if (question.messageId) {
             try {
               await questionChannel.messages.fetch(question.messageId);
-            } catch {
+            } catch (error) {
+              console.log(`[sync/phase3] DiscordAPIError: Question message #${question.messageId} not found, clearing`);
               repository.clearQuestionMessageId(question.id);
               results.questionMessagesCleaned++;
             }
@@ -87,18 +112,106 @@ module.exports = {
         }
       }
 
-      console.log(`[sync] Sync completed by ${interaction.user.tag}: added=${results.membersAdded}, removed=${results.membersRemoved}, attendees=${results.attendeesRemoved}, lectures=${results.lectureMessagesCleaned}, questions=${results.questionMessagesCleaned}`);
+      const practiceChannel = guild.channels.cache.get(config.channels.practice);
+      const practicePlans = repository.getAllPersonalPracticePlans();
+      if (practiceChannel) {
+        for (const plan of practicePlans) {
+          if (plan.messageId) {
+            try {
+              await practiceChannel.messages.fetch(plan.messageId);
+            } catch (error) {
+              console.log(`[sync/phase3] DiscordAPIError: Practice plan message #${plan.messageId} not found, clearing`);
+              repository.clearPracticePlanMessageId(plan.id);
+              results.practiceMessagesCleaned++;
+            }
+          }
+        }
+      }
+
+      const quizHistory = repository.getAllQuizPublishHistory();
+      if (quizHistory && quizHistory.length > 0) {
+        const quizConfigStmt = repository.db.prepare('SELECT quiz_channel_id FROM quiz_config WHERE id = 1');
+        const quizConfig = quizConfigStmt.get();
+        const quizChannel = quizConfig?.quiz_channel_id
+          ? guild.channels.cache.get(quizConfig.quiz_channel_id)
+          : null;
+
+        if (quizChannel) {
+          for (const history of quizHistory) {
+            if (history.message_id) {
+              try {
+                await quizChannel.messages.fetch(history.message_id);
+              } catch (error) {
+                console.log(`[sync/phase3] DiscordAPIError: Quiz message #${history.message_id} not found, clearing`);
+                repository.clearQuizPublishHistoryMessageId(history.id);
+                results.quizMessagesCleaned++;
+              }
+            }
+          }
+        }
+      }
+      console.log(`[sync/phase3] Completed: lectures=${results.lectureMessagesCleaned}, questions=${results.questionMessagesCleaned}, practice=${results.practiceMessagesCleaned}, quiz=${results.quizMessagesCleaned}`);
+
+      // Phase 4: Activity points cleanup
+      console.log('[sync/phase4] Starting activity points cleanup');
+      const allActivityPoints = repository.getAllActivityPoints();
+      for (const activityPoint of allActivityPoints) {
+        if (!guildMemberIds.has(activityPoint.user_id)) {
+          results.pointsRemoved += repository.deleteActivityPointsByUserId(activityPoint.user_id);
+          results.accumulationLogsRemoved += repository.deleteAccumulationLogsByUserId(activityPoint.user_id);
+        }
+      }
+      console.log(`[sync/phase4] Completed: points=${results.pointsRemoved}, logs=${results.accumulationLogsRemoved}`);
+
+      // Phase 5: Personal practice cleanup
+      console.log('[sync/phase5] Starting personal practice cleanup');
+      for (const plan of practicePlans) {
+        if (!guildMemberIds.has(plan.userId)) {
+          if (plan.messageId && practiceChannel) {
+            try {
+              const message = await practiceChannel.messages.fetch(plan.messageId);
+              await message.delete();
+              console.log(`[sync/phase5] Deleted orphaned practice plan message #${plan.messageId}`);
+            } catch (error) {
+              console.log(`[sync/phase5] DiscordAPIError: Could not delete practice plan message #${plan.messageId}:`, error.message);
+            }
+          }
+
+          const records = repository.getPersonalPracticeRecords(plan.id);
+          results.practiceRecordsRemoved += records.length;
+
+          repository.deletePersonalPracticePlan(plan.id);
+          results.practicesRemoved++;
+        }
+      }
+      console.log(`[sync/phase5] Completed: practices=${results.practicesRemoved}, records=${results.practiceRecordsRemoved}`);
+
+      // Phase 6: Quiz publish history cleanup
+      console.log('[sync/phase6] Starting quiz publish history cleanup');
+      results.quizHistoryCleaned = repository.deleteOrphanQuizPublishHistory();
+      console.log(`[sync/phase6] Completed: orphanHistory=${results.quizHistoryCleaned}`);
+
+      console.log(`[sync] Sync completed by ${interaction.user.tag}: Phase1(+${results.membersAdded}/-${results.membersRemoved}), Phase2(lec=${results.lectureAttendeesRemoved}/q=${results.questionAttendeesRemoved}), Phase3(lec=${results.lectureMessagesCleaned}/q=${results.questionMessagesCleaned}/prac=${results.practiceMessagesCleaned}/quiz=${results.quizMessagesCleaned}), Phase4(pts=${results.pointsRemoved}/logs=${results.accumulationLogsRemoved}), Phase5(plans=${results.practicesRemoved}/rec=${results.practiceRecordsRemoved}), Phase6(hist=${results.quizHistoryCleaned})`);
+
       await interaction.editReply({
         content: strings.sync.complete(
           results.membersAdded,
           results.membersRemoved,
-          results.attendeesRemoved,
+          results.lectureAttendeesRemoved,
+          results.questionAttendeesRemoved,
           results.lectureMessagesCleaned,
           results.questionMessagesCleaned,
+          results.practiceMessagesCleaned,
+          results.quizMessagesCleaned,
+          results.pointsRemoved,
+          results.accumulationLogsRemoved,
+          results.practicesRemoved,
+          results.practiceRecordsRemoved,
+          results.quizHistoryCleaned,
         ),
       });
     } catch (error) {
-      console.error(`[sync] Sync failed for ${interaction.user.tag}:`, error);
+      console.error(`[sync] ${error.constructor.name}: Sync failed for ${interaction.user.tag}:`, error);
       await interaction.editReply({
         content: strings.sync.error(error.message),
       });

--- a/src/presentation/interfaces/strings.js
+++ b/src/presentation/interfaces/strings.js
@@ -37,7 +37,7 @@ const PARAM_MAP = {
   'inactive.configSaved': ['days'],
   'inactive.configDisplay': ['days'],
   // Sync command strings
-  'sync.complete': ['membersAdded', 'membersRemoved', 'attendeesRemoved', 'lectureMessagesCleaned', 'questionMessagesCleaned'],
+  'sync.complete': ['membersAdded', 'membersRemoved', 'lectureAttendeesRemoved', 'questionAttendeesRemoved', 'lectureMessagesCleaned', 'questionMessagesCleaned', 'practiceMessagesCleaned', 'quizMessagesCleaned', 'pointsRemoved', 'accumulationLogsRemoved', 'practicesRemoved', 'practiceRecordsRemoved', 'quizHistoryCleaned'],
   'sync.error': ['error'],
   // Point controller strings
   'point.myPoints': ['points'],


### PR DESCRIPTION
Add sync coverage for quiz, activity points, and personal practice tables that were added by recent features. Phase 2 now includes question_attendees cleanup. Phase 3 validates practice plan and quiz message IDs. New Phase 4-6 handle activity points, personal practice, and orphaned quiz publish history cleanup.