### PR TITLE
Replace Docker-based deployment with bare-metal shell scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,198 +1,199 @@
 # Mettaton
 
-Raspberry Pi 3B+에서 동작하는 Discord 서버 관리 봇.
+Raspberry Pi 3B+에서 동작하는 Discord 서버 관리 봇
 
-## Tech Stack
+## 기술 스택
 
-- **Runtime**: Node.js LTS (Alpine)
-- **Framework**: discord.js v14
-- **Database**: better-sqlite3 (SQLite, WAL mode)
-- **Tools**: puppeteer-core, axios, node-cron
-- **Test**: Jest
-- **Infra**: Docker, Docker Compose, systemd
+- **런타임**: Node.js 20.x LTS
+- **프레임워크**: discord.js v14
+- **데이터베이스**: better-sqlite3 (SQLite, WAL mode)
+- **도구**: puppeteer-core, axios, node-cron
+- **테스트**: Jest
+- **인프라**: systemd (Bare-metal, Docker 미사용)
 
-## Features
+## 기능
 
-| Category | Commands |
-|----------|----------|
-| Schedule | `/schedule register`, `/schedule delete`, `/schedule list` |
-| Question | `/question register`, `/question delete`, `/question list`, `/question answer` |
-| Meeting | `/meeting config` |
-| Points | `/point myPoints`, `/point ranking`, `/point config` |
-| Inactive | `/inactive list`, `/inactive kick`, `/inactive config`, `/inactive configView` |
-| Admin | `/string config`, `/sync sync` |
+| 카테고리 | 명령어 |
+|----------|--------|
+| 스케줄 | `/schedule register`, `/schedule delete`, `/schedule list` |
+| 질문 | `/question register`, `/question delete`, `/question list`, `/question answer` |
+| 회의 | `/meeting config` |
+| 포인트 | `/point myPoints`, `/point ranking`, `/point config` |
+| 비활성 관리 | `/inactive list`, `/inactive kick`, `/inactive config`, `/inactive configView` |
+| 관리자 | `/string config`, `/sync sync` |
 
-Event handlers: `guildMemberAdd`, `messageCreate`, `messageDelete`, `messageReactionAdd`, `messageReactionRemove`
+이벤트 핸들러: `guildMemberAdd`, `messageCreate`, `messageDelete`, `messageReactionAdd`, `messageReactionRemove`
 
 ---
 
-## Prerequisites
+## 사전 요구사항
 
 - Raspberry Pi 3B+ (Raspbian OS)
 - Git
-- Internet connection
-- Discord Bot Token ([Discord Developer Portal](https://discord.com/developers/applications))
+- 인터넷 연결
+- Discord 봇 토큰 ([Discord Developer Portal](https://discord.com/developers/applications))
 
 ---
 
-## 1. Initial Setup
+## 1. 초기 설치
 
-### 1-1. Clone the repository
+### 1-1. 프로젝트 클론
 
 ```bash
 git clone https://github.com/arslanRedemar/mettaton.git /home/pi/mettaton
 cd /home/pi/mettaton
 ```
 
-### 1-2. Run the setup script
+### 1-2. 설치 스크립트 실행
 
 ```bash
 bash scripts/setup.sh
 ```
 
-This script performs the following 10 steps automatically:
+설치 스크립트가 자동으로 수행하는 작업:
 
-| Step | Action |
-|------|--------|
-| 1 | System update (`apt-get update && upgrade`) |
-| 2 | Docker installation |
-| 3 | Docker Compose verification |
-| 4 | Project directory setup |
-| 5 | Data directories creation (`data/`, `moon_calendars/`) |
-| 6 | `.env` template generation |
-| 7 | Bot systemd service registration (`mettaton.service`) |
-| 8 | Backup and log directories creation (`backups/`, `logs/`) |
-| 9 | Git config for auto-updates + `update.sh` permission |
-| 10 | Auto-update timer registration and activation |
+| 단계 | 작업 |
+|------|------|
+| 1 | 시스템 업데이트 (`apt-get update && upgrade`) |
+| 2 | Node.js 20.x 설치 (NodeSource 저장소) |
+| 3 | 빌드 도구 설치 (python3, make, g++, build-essential) |
+| 4 | Chromium 브라우저 및 한국어 폰트 설치 |
+| 5 | 프로젝트 디렉터리 확인 |
+| 6 | 데이터 디렉터리 생성 (`data/`, `moon_calendars/`, `backups/`, `logs/`) |
+| 7 | `.env` 템플릿 생성 |
+| 8 | npm 의존성 설치 (`npm ci`) |
+| 9 | systemd 서비스 등록 (봇 + 자동 업데이트) |
+| 10 | Git 설정 및 자동 업데이트 타이머 활성화 |
 
-### 1-3. Configure environment variables
+### 1-3. 환경 변수 설정
 
 ```bash
 nano /home/pi/mettaton/.env
 ```
 
 ```env
-TOKEN=your_discord_bot_token
-CLIENT_ID=your_client_id
-GUILD_ID=your_guild_id
-GREETING_CHANNEL_ID=your_greeting_channel_id
-SCHEDULE_CHANNEL_ID=your_schedule_channel_id
-QUESTION_CHANNEL_ID=your_question_channel_id
-PRACTICE_CHANNEL_ID=your_practice_channel_id
-DB_PATH=/app/data/mettaton.db
+TOKEN=디스코드_봇_토큰
+CLIENT_ID=클라이언트_ID
+GUILD_ID=길드_ID
+GREETING_CHANNEL_ID=인사_채널_ID
+SCHEDULE_CHANNEL_ID=스케줄_채널_ID
+QUESTION_CHANNEL_ID=질문_채널_ID
+PRACTICE_CHANNEL_ID=연습_채널_ID
+DB_PATH=./data/mettaton.db
+CHROMIUM_PATH=/usr/bin/chromium-browser
 ```
 
-| Variable | Description |
-|----------|-------------|
-| `TOKEN` | Discord bot token |
-| `CLIENT_ID` | Discord application client ID |
-| `GUILD_ID` | Target Discord server ID |
-| `GREETING_CHANNEL_ID` | Channel for welcome messages |
-| `SCHEDULE_CHANNEL_ID` | Channel for schedule announcements |
-| `QUESTION_CHANNEL_ID` | Channel for Q&A |
-| `PRACTICE_CHANNEL_ID` | Channel for practice sessions |
-| `DB_PATH` | SQLite DB path inside container |
+| 변수 | 설명 |
+|------|------|
+| `TOKEN` | Discord 봇 토큰 |
+| `CLIENT_ID` | Discord 애플리케이션 클라이언트 ID |
+| `GUILD_ID` | 대상 Discord 서버 ID |
+| `GREETING_CHANNEL_ID` | 환영 메시지 채널 |
+| `SCHEDULE_CHANNEL_ID` | 스케줄 알림 채널 |
+| `QUESTION_CHANNEL_ID` | Q&A 채널 |
+| `PRACTICE_CHANNEL_ID` | 연습 세션 채널 |
+| `DB_PATH` | SQLite 데이터베이스 경로 |
+| `CHROMIUM_PATH` | Chromium 브라우저 실행 경로 |
 
-### 1-4. Start the bot
+### 1-4. 봇 실행
 
 ```bash
 sudo reboot
 ```
 
-After reboot, the bot starts automatically via systemd. Alternatively:
+재부팅 후 systemd가 자동으로 봇을 시작합니다. 또는 수동으로:
 
 ```bash
 sudo systemctl start mettaton
 ```
 
-### 1-5. Verify
+### 1-5. 동작 확인
 
 ```bash
-# Check container status
-docker ps
+# 봇 서비스 상태 확인
+sudo systemctl status mettaton
 
-# View bot logs
-docker logs -f mettaton-bot
+# 실시간 로그 확인
+journalctl -u mettaton -f
 
-# Check auto-update timer
+# 자동 업데이트 타이머 확인
 systemctl status mettaton-update.timer
 ```
 
 ---
 
-## 2. CI/CD Pipeline
+## 2. CI/CD 파이프라인
 
-### Architecture
+### 아키텍처
 
 ```
-GitHub (main branch)
+GitHub (main 브랜치)
   |
-  +-- GitHub Actions -----> Test + Docker build verification
-  |                         (runs on GitHub servers)
-  |
-  +-- Raspberry Pi (polls every 5 min)
-       +-- systemd timer --> update.sh
-            +-- git fetch & detect changes
-            +-- backup DB + data
-            +-- git pull + docker compose rebuild
-            +-- health check (60s)
-            +-- rollback on failure
-            +-- cleanup old images
+  +-- Raspberry Pi (5분마다 폴링)
+       +-- systemd 타이머 --> update.sh
+            +-- git fetch로 변경 감지
+            +-- DB + 데이터 백업
+            +-- git pull + npm ci (의존성 변경 시)
+            +-- systemctl restart로 봇 재시작
+            +-- 헬스체크 (60초)
+            +-- 실패 시 자동 롤백
 ```
 
-### How Auto-Update Works
+### 자동 업데이트 동작 방식
 
-The systemd timer (`mettaton-update.timer`) triggers `update.sh` every 5 minutes:
+systemd 타이머(`mettaton-update.timer`)가 5분마다 `update.sh`를 실행합니다:
 
-1. **Change detection**: `git fetch origin main` + compare local/remote HEAD
-2. **Backup**: Copy `data/` and `moon_calendars/` to `backups/backup_<timestamp>_<commit>/`
-3. **Deploy**: `git pull` + `docker compose down` + `docker compose up -d --build`
-4. **Health check**: Verify container is running with no crash loops (6 retries, 10s interval)
-5. **On failure**: Automatic rollback (restore code via `git reset --hard` + restore data from backup)
-6. **Cleanup**: Rotate backups (keep last 5), prune unused Docker images
-
-### GitHub Actions CI
-
-On every push to `main` or PR targeting `main`, GitHub Actions runs:
-
-1. **Test job**: Install dependencies, run Jest unit tests, run shell script tests
-2. **Docker build job**: Verify `Dockerfile` builds successfully (runs only after tests pass)
+1. **변경 감지**: `git fetch origin main` + 로컬/원격 HEAD 비교
+2. **백업**: `data/`, `moon_calendars/`, `package-lock.json`을 `backups/backup_<타임스탬프>_<커밋>/`에 복사
+3. **배포**: `git pull` + 의존성 변경 시 `npm ci` + `systemctl restart mettaton`
+4. **헬스체크**: 서비스가 정상 실행 중인지 확인 (6회 재시도, 10초 간격)
+5. **실패 시**: 자동 롤백 (`git reset --hard`로 코드 복원 + 백업에서 데이터 복원 + `npm ci` + 서비스 재시작)
+6. **정리**: 백업 로테이션 (최근 5개만 유지)
 
 ---
 
-## 3. Manual Operations
+## 3. 수동 조작
 
-### Start / Stop
+### 시작 / 중지
 
 ```bash
-# Start
+# systemd를 통한 시작
+sudo systemctl start mettaton
+
+# systemd를 통한 중지
+sudo systemctl stop mettaton
+
+# 재시작
+sudo systemctl restart mettaton
+
+# 수동 시작 (포그라운드, 디버깅용)
 bash /home/pi/mettaton/scripts/start.sh
 
-# Stop
+# 수동 중지
 bash /home/pi/mettaton/scripts/stop.sh
 ```
 
-### Force Deploy
+### 강제 배포
 
-Skip the change-detection check and deploy immediately:
+변경 감지를 건너뛰고 즉시 배포:
 
 ```bash
 bash /home/pi/mettaton/scripts/update.sh --force --verbose
 ```
 
-| Flag | Description |
-|------|-------------|
-| `--force` | Skip new-commit check, deploy immediately |
-| `--verbose` | Print detailed output to stdout |
-| `--help` | Show usage |
+| 플래그 | 설명 |
+|--------|------|
+| `--force` | 새 커밋 확인 건너뛰고 즉시 배포 |
+| `--verbose` | 상세 출력을 stdout에 표시 |
+| `--help` | 사용법 표시 |
 
-### View Deploy Logs
+### 배포 로그 확인
 
 ```bash
 tail -f /home/pi/mettaton/logs/deploy.log
 ```
 
-Example log output:
+로그 출력 예시:
 
 ```
 [2026-01-31 14:00:02] [INFO] ========== Update check started ==========
@@ -201,184 +202,197 @@ Example log output:
 [2026-01-31 14:00:04] [INFO] Creating backup: backup_20260131_140004_a1b2c3d
 [2026-01-31 14:00:05] [INFO] Pulling latest code...
 [2026-01-31 14:00:06] [INFO] Code updated to: e5f6g7h
-[2026-01-31 14:00:06] [INFO] Stopping current container...
-[2026-01-31 14:00:08] [INFO] Building and starting container...
-[2026-01-31 14:00:45] [INFO] Container healthy. No restarts detected.
-[2026-01-31 14:00:45] [INFO] Deployment successful! (e5f6g7h)
-[2026-01-31 14:00:46] [INFO] ========== Update check finished ==========
+[2026-01-31 14:00:06] [INFO] Dependencies unchanged. Skipping npm ci.
+[2026-01-31 14:00:07] [INFO] Restarting bot service...
+[2026-01-31 14:00:17] [INFO] Bot is running. (check 1/6)
+[2026-01-31 14:00:17] [INFO] Deployment successful! (e5f6g7h)
+[2026-01-31 14:00:17] [INFO] ========== Update check finished ==========
 ```
 
-### Check systemd Services
+### systemd 서비스 관리
 
 ```bash
-# Bot service status
+# 봇 서비스 상태
 systemctl status mettaton
 
-# Auto-update timer status
+# 자동 업데이트 타이머 상태
 systemctl status mettaton-update.timer
 
-# Auto-update service logs (journalctl)
+# 업데이트 서비스 로그 (journalctl)
 journalctl -u mettaton-update.service --no-pager -n 20
 
-# Disable auto-updates
+# 자동 업데이트 비활성화
 sudo systemctl stop mettaton-update.timer
 sudo systemctl disable mettaton-update.timer
 
-# Re-enable auto-updates
+# 자동 업데이트 다시 활성화
 sudo systemctl enable mettaton-update.timer
 sudo systemctl start mettaton-update.timer
 ```
 
-### Manage Backups
+### 백업 관리
 
 ```bash
-# List backups
+# 백업 목록 확인
 ls -lt /home/pi/mettaton/backups/
 
-# Manual backup restore
+# 수동 백업 복원
 cp -a /home/pi/mettaton/backups/backup_20260131_140004_a1b2c3d/data/ /home/pi/mettaton/data/
 ```
 
-Backups are automatically rotated to keep the last 5.
+백업은 자동으로 로테이션되며 최근 5개만 유지됩니다.
 
 ---
 
-## 4. Project Structure
+## 4. 프로젝트 구조
 
 ```
 scripts/
-  setup.sh                    # Initial Pi setup (10 steps)
-  start.sh                    # Manual start
-  stop.sh                     # Manual stop
-  update.sh                   # Auto-update with backup & rollback
-  mettaton.service             # systemd: bot auto-start on boot
-  mettaton-update.service      # systemd: update script wrapper
-  mettaton-update.timer        # systemd: 5-min polling timer
-
-.github/workflows/
-  ci.yml                      # GitHub Actions: test + Docker build
+  setup.sh                    # 초기 설치 스크립트 (10단계)
+  start.sh                    # 수동 시작
+  stop.sh                     # 수동 중지
+  update.sh                   # 자동 업데이트 (백업 + 롤백 포함)
+  mettaton.service             # systemd: 부팅 시 봇 자동 시작
+  mettaton-update.service      # systemd: 업데이트 스크립트 래퍼
+  mettaton-update.timer        # systemd: 5분 폴링 타이머
 
 core/
-  config/                     # Environment config
-  di/                         # Dependency injection
-  errors/                     # Custom errors
-  types/                      # Type definitions
-  utils/                      # Utilities
+  config/                     # 환경변수 및 앱 설정
+  di/                         # 의존성 주입 설정
+  errors/                     # 커스텀 에러 클래스
+  types/                      # 공통 타입 정의
+  utils/                      # 공통 유틸리티
 
 src/
   data/
-    datasource/               # DB + Discord client init
-    mappers/                  # Entity <-> Model mappers
-    models/                   # DB schemas
-    repositories/             # Repository implementations
+    datasource/               # DB 연결 및 초기화
+    mappers/                  # Entity <-> Model 변환
+    models/                   # DB 스키마 정의
+    repositories/             # Repository 구현체
   domain/
-    entities/                 # Business entities
-    repositories/             # Repository interfaces
-    usecases/                 # Business logic services
+    entities/                 # 비즈니스 엔티티
+    repositories/             # Repository 인터페이스 (추상)
+    usecases/                 # 비즈니스 로직 서비스
   presentation/
-    controllers/              # Slash command handlers
-    dto/                      # Data transfer objects
-    interfaces/               # Discord event handlers
-    views/                    # Response formatters
+    controllers/              # 슬래시 명령어 핸들러
+    dto/                      # 데이터 전송 객체
+    interfaces/               # Discord 이벤트 핸들러
+    views/                    # 응답 뷰/포맷터
 
 tests/
-  unit/                       # Jest unit tests
-  integration/                # Shell script tests
+  unit/                       # Jest 유닛 테스트
+  integration/                # 통합 테스트
 ```
 
 ---
 
-## 5. Development
+## 5. 개발
 
-### Run Tests
+### 테스트 실행
 
 ```bash
-# Unit tests
+# 유닛 테스트
 npm test
 
-# Shell script tests
-bash tests/integration/scripts/run_all_tests.sh
-
-# All tests
-npm run test:all
-
-# Watch mode
+# 감시 모드
 npm run test:watch
 
-# Coverage
+# 커버리지 리포트
 npm run test:coverage
 ```
 
-### Local Development (without Docker)
+### 로컬 개발
 
 ```bash
 npm install
-cp .env.example .env
-# Edit .env with your values
+# .env 파일에 환경 변수 설정
 npm start
 ```
 
 ---
 
-## 6. Data Persistence
+## 6. 데이터 영속성
 
-The following data survives deployments through Docker volume mounts:
+배포 시에도 유지되는 데이터:
 
-| Host Path | Container Path | Content |
-|-----------|---------------|---------|
-| `./data/` | `/app/data/` | SQLite database (`mettaton.db`) |
-| `./moon_calendars/` | `/app/moon_calendars/` | Calendar image files |
+| 경로 | 내용 |
+|------|------|
+| `./data/` | SQLite 데이터베이스 (`mettaton.db`) |
+| `./moon_calendars/` | 달력 이미지 파일 |
 
-The database uses WAL mode and contains 11 tables including `questions`, `settings`, `meeting_config`, `bot_strings`, `member_activity`, `activity_points`, and more.
-
----
-
-## 7. Raspberry Pi Protections
-
-| Protection | Mechanism |
-|------------|-----------|
-| CPU priority | `Nice=19` (lowest) on update service |
-| I/O priority | `IOSchedulingClass=idle` on update service |
-| Memory limit | `MemoryMax=256M` on update service |
-| SD card wear | `RandomizedDelaySec=30s` on timer |
-| Disk space | `docker image prune` after each deploy |
-| Backup limit | Keep last 5, auto-rotate older ones |
-| Concurrent run | Lock file prevents overlapping updates |
+데이터베이스는 WAL 모드를 사용하며, `questions`, `settings`, `meeting_config`, `bot_strings`, `member_activity`, `activity_points` 등 테이블을 포함합니다.
 
 ---
 
-## Troubleshooting
+## 7. Raspberry Pi 보호 메커니즘
 
-**Bot not starting after reboot**
+| 보호 항목 | 메커니즘 |
+|-----------|----------|
+| CPU 우선순위 | 업데이트 서비스에 `Nice=19` (최저 우선순위) |
+| I/O 우선순위 | 업데이트 서비스에 `IOSchedulingClass=idle` |
+| 메모리 제한 | 봇 및 업데이트 서비스에 `MemoryMax=512M` |
+| SD 카드 보호 | 타이머에 `RandomizedDelaySec=30s` |
+| 백업 용량 제한 | 최근 5개만 유지, 이전 백업 자동 삭제 |
+| 동시 실행 방지 | Lock 파일로 업데이트 중복 실행 차단 |
+| 크래시 복구 | `Restart=on-failure`로 봇 자동 재시작 |
+
+---
+
+## 문제 해결
+
+**봇이 재부팅 후 시작되지 않을 때**
 ```bash
-systemctl status mettaton
-docker logs mettaton-bot
+sudo systemctl status mettaton
+journalctl -u mettaton --no-pager -n 50
 ```
 
-**Auto-update not working**
+**자동 업데이트가 동작하지 않을 때**
 ```bash
 systemctl status mettaton-update.timer
+systemctl list-timers | grep mettaton
 tail -20 /home/pi/mettaton/logs/deploy.log
 ```
 
-**Container crash loop**
+**봇이 반복적으로 크래시할 때**
 ```bash
-docker inspect --format='{{.RestartCount}}' mettaton-bot
-docker logs --tail 50 mettaton-bot
+# 최근 재시작 로그 확인
+journalctl -u mettaton --no-pager -n 100
+
+# 서비스 재시작 횟수 확인
+systemctl show mettaton --property=NRestarts
 ```
 
-**Manual rollback**
+**수동 롤백**
 ```bash
 cd /home/pi/mettaton
-ls backups/                           # Find a backup
-docker compose down
-git reset --hard <commit_hash>
-cp -a backups/<backup_name>/data/ data/
-docker compose up -d --build
+ls backups/                           # 백업 목록 확인
+sudo systemctl stop mettaton
+git reset --hard <커밋_해시>
+cp -a backups/<백업_이름>/data/ data/
+npm ci --only=production              # 의존성 복원
+sudo systemctl start mettaton
 ```
 
-**Disk space full**
+**better-sqlite3 빌드 실패 시**
 ```bash
-docker system prune -a
+sudo apt-get install -y python3 make g++ build-essential
+rm -rf node_modules
+npm ci --only=production
+```
+
+**Chromium 경로 오류 시**
+```bash
+# 실제 경로 확인
+which chromium-browser || which chromium
+# .env 파일의 CHROMIUM_PATH를 위 결과로 수정
+```
+
+**디스크 용량 부족 시**
+```bash
+# 백업 확인 및 수동 정리
 ls -lh backups/
+rm -rf backups/backup_오래된_백업/
+
+# npm 캐시 정리
+npm cache clean --force
 ```

--- a/scripts/mettaton-update.service
+++ b/scripts/mettaton-update.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Mettaton Discord Bot Auto-Update
-After=network-online.target docker.service
+After=network-online.target
 Wants=network-online.target
 
 [Service]

--- a/scripts/mettaton.service
+++ b/scripts/mettaton.service
@@ -1,16 +1,24 @@
 [Unit]
 Description=Mettaton Discord Bot
-Requires=docker.service
-After=docker.service network-online.target
+After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
+Type=simple
+User=pi
 WorkingDirectory=/home/pi/mettaton
-ExecStart=/usr/bin/docker compose up -d --build
-ExecStop=/usr/bin/docker compose down
-TimeoutStartSec=900
+ExecStart=/usr/bin/node src/index.js
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=mettaton
+
+# Environment
+EnvironmentFile=/home/pi/mettaton/.env
+
+# Resource limits for Raspberry Pi 3B+
+MemoryMax=512M
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,87 +1,101 @@
 #!/bin/bash
 
 # Mettaton Discord Bot - Raspberry Pi Setup Script
-# Raspbian OS automated setup with auto-update pipeline
+# Bare-metal (no Docker) automated setup with auto-update pipeline
 
 set -e
 
 echo "=========================================="
-echo "  Mettaton Discord Bot 설치 스크립트"
+echo "  Mettaton Discord Bot Setup (Bare-metal)"
 echo "=========================================="
+
+PROJECT_DIR="/home/pi/mettaton"
+NODE_MAJOR=20
 
 # 1. System update
 echo "[1/10] Updating system..."
 sudo apt-get update && sudo apt-get upgrade -y
 
-# 2. Install Docker
-echo "[2/10] Installing Docker..."
-if ! command -v docker &> /dev/null; then
-    curl -fsSL https://get.docker.com -o get-docker.sh
-    sudo sh get-docker.sh
-    sudo usermod -aG docker $USER
-    rm get-docker.sh
-    echo "Docker installed"
+# 2. Install Node.js 20.x LTS
+echo "[2/10] Installing Node.js ${NODE_MAJOR}.x..."
+if ! command -v node &> /dev/null || [ "$(node -v | cut -d. -f1 | tr -d 'v')" -lt "$NODE_MAJOR" ]; then
+    sudo apt-get install -y ca-certificates curl gnupg
+    sudo mkdir -p /etc/apt/keyrings
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
+        | sudo tee /etc/apt/sources.list.d/nodesource.list
+    sudo apt-get update
+    sudo apt-get install -y nodejs
+    echo "Node.js $(node -v) installed"
 else
-    echo "Docker already installed"
+    echo "Node.js $(node -v) already installed"
 fi
 
-# 3. Verify Docker Compose
-echo "[3/10] Verifying Docker Compose..."
-if ! docker compose version &> /dev/null; then
-    sudo apt-get install -y docker-compose-plugin
-fi
+# 3. Install build tools (required for better-sqlite3 native compilation)
+echo "[3/10] Installing build tools..."
+sudo apt-get install -y python3 make g++ build-essential
 
-# 4. Setup project directory
-echo "[4/10] Setting up project directory..."
-PROJECT_DIR="/home/pi/mettaton"
+# 4. Install Chromium and Korean fonts (required for puppeteer)
+echo "[4/10] Installing Chromium and fonts..."
+sudo apt-get install -y chromium-browser fonts-noto-cjk
 
+# 5. Setup project directory
+echo "[5/10] Setting up project directory..."
 if [ ! -d "$PROJECT_DIR" ]; then
-    echo "Please clone the project to $PROJECT_DIR:"
-    echo "git clone https://github.com/arslanRedemar/mettaton.git $PROJECT_DIR"
+    echo "Please clone the project first:"
+    echo "  git clone https://github.com/arslanRedemar/mettaton.git $PROJECT_DIR"
+    echo "Then re-run this script."
+    exit 1
 fi
 
-# 5. Create data directories
-echo "[5/10] Creating data directories..."
+# 6. Create data directories
+echo "[6/10] Creating data directories..."
 mkdir -p "$PROJECT_DIR/data"
 mkdir -p "$PROJECT_DIR/moon_calendars"
+mkdir -p "$PROJECT_DIR/backups"
+mkdir -p "$PROJECT_DIR/logs"
 
-# 6. Create environment file
-echo "[6/10] Setting up environment variables..."
+# 7. Create environment file
+echo "[7/10] Setting up environment variables..."
 if [ ! -f "$PROJECT_DIR/.env" ]; then
     cat > "$PROJECT_DIR/.env" << 'EOF'
 TOKEN=your_discord_bot_token
 CLIENT_ID=your_client_id
 GUILD_ID=your_guild_id
-GREETING_CHANEL_ID=your_greeting_channel_id
-DB_PATH=/app/data/mettaton.db
+GREETING_CHANNEL_ID=your_greeting_channel_id
+SCHEDULE_CHANNEL_ID=your_schedule_channel_id
+QUESTION_CHANNEL_ID=your_question_channel_id
+PRACTICE_CHANNEL_ID=your_practice_channel_id
+DB_PATH=./data/mettaton.db
+CHROMIUM_PATH=/usr/bin/chromium-browser
 EOF
     echo ".env file created. Please edit the values:"
     echo "  nano $PROJECT_DIR/.env"
 fi
 
-# 7. Register systemd bot service
-echo "[7/10] Registering bot service for auto-start..."
-sudo cp "$PROJECT_DIR/scripts/mettaton.service" /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable mettaton.service
-
-# 8. Create backup and log directories
-echo "[8/10] Creating backup and log directories..."
-mkdir -p "$PROJECT_DIR/backups"
-mkdir -p "$PROJECT_DIR/logs"
-
-# 9. Configure git for auto-updates
-echo "[9/10] Configuring git for auto-updates..."
+# 8. Install npm dependencies
+echo "[8/10] Installing npm dependencies..."
 cd "$PROJECT_DIR"
-git config pull.rebase false
-chmod +x "$PROJECT_DIR/scripts/update.sh"
+npm ci --only=production
 
-# 10. Enable auto-update timer
-echo "[10/10] Enabling auto-update timer..."
+# 9. Register systemd services
+echo "[9/10] Registering systemd services..."
+sudo cp "$PROJECT_DIR/scripts/mettaton.service" /etc/systemd/system/
 sudo cp "$PROJECT_DIR/scripts/mettaton-update.service" /etc/systemd/system/
 sudo cp "$PROJECT_DIR/scripts/mettaton-update.timer" /etc/systemd/system/
 sudo systemctl daemon-reload
+sudo systemctl enable mettaton.service
 sudo systemctl enable mettaton-update.timer
+
+# 10. Configure git for auto-updates
+echo "[10/10] Configuring git for auto-updates..."
+cd "$PROJECT_DIR"
+git config pull.rebase false
+chmod +x "$PROJECT_DIR/scripts/update.sh"
+chmod +x "$PROJECT_DIR/scripts/start.sh"
+chmod +x "$PROJECT_DIR/scripts/stop.sh"
+
 sudo systemctl start mettaton-update.timer
 
 echo ""
@@ -91,11 +105,10 @@ echo "=========================================="
 echo ""
 echo "Next steps:"
 echo "1. Edit .env file: nano $PROJECT_DIR/.env"
-echo "2. Reboot or start service: sudo systemctl start mettaton"
-echo "3. View bot logs: docker logs -f mettaton-bot"
+echo "2. Start the bot: sudo systemctl start mettaton"
+echo "3. View bot logs: journalctl -u mettaton -f"
 echo "4. Check DB: sqlite3 $PROJECT_DIR/data/mettaton.db"
 echo "5. Check auto-update timer: systemctl status mettaton-update.timer"
 echo "6. View deploy logs: tail -f $PROJECT_DIR/logs/deploy.log"
 echo "7. Manual update: bash $PROJECT_DIR/scripts/update.sh --force --verbose"
 echo ""
-echo "* Reboot recommended for Docker group changes: sudo reboot"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# 수동 시작 스크립트
-cd /home/pi/mettaton
-docker compose up -d --build
-echo "Mettaton bot started!"
-docker logs -f mettaton-bot
+# Mettaton Discord Bot - Manual Start Script
+
+PROJECT_DIR="/home/pi/mettaton"
+
+echo "Starting Mettaton bot..."
+cd "$PROJECT_DIR"
+node src/index.js

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 
-# 수동 중지 스크립트
-cd /home/pi/mettaton
-docker compose down
-echo "Mettaton bot stopped!"
+# Mettaton Discord Bot - Manual Stop Script
+
+echo "Stopping Mettaton bot..."
+
+if sudo systemctl is-active --quiet mettaton; then
+    sudo systemctl stop mettaton
+    echo "Mettaton bot stopped (via systemd)."
+else
+    PID=$(pgrep -f "node src/index.js")
+    if [ -n "$PID" ]; then
+        kill "$PID"
+        echo "Mettaton bot stopped (PID: $PID)."
+    else
+        echo "Mettaton bot is not running."
+    fi
+fi


### PR DESCRIPTION
Remove all Docker dependencies (Dockerfile, docker-compose) from the deployment pipeline and run Node.js directly on Raspberry Pi 3B+. Scripts now install Node.js, Chromium, and build tools natively, manage the bot via systemd, and handle updates with npm ci. README rewritten in Korean as a full setup tutorial.